### PR TITLE
fix: x402-axios version being set to undefined in sync workflow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -55,6 +55,8 @@ jobs:
 
       - name: Inject resolved x402-axios version
         if: steps.npm.outputs.version != '0.0.0'
+        env:
+          V: ${{ steps.npm.outputs.version }}
         run: |
           node -e '
             const fs = require("fs");
@@ -64,8 +66,7 @@ jobs:
               j.dependencies["x402-axios"] = `^${process.env.V}`;
               fs.writeFileSync(p, JSON.stringify(j, null, 2));
             }
-          ' \
-          V='${{ steps.npm.outputs.version }}'
+          '
 
       - name: Determine if there are changes
         run: |


### PR DESCRIPTION
## Issue
The sync workflow sets x402-axios version to `undefined` instead of the actual npm version.

## Cause
Environment variable `V` was set after the node command ran, so `process.env.V` was undefined.

## Fix
Moved `V` to step-level `env:` so it's available when the script executes.

## Tested
- Reproduced bug: version was `^undefined`
- Verified fix: version correctly set to `^0.7.0`