### PR TITLE
chore: follow upstream @x402/axios versioning

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -30,11 +30,6 @@ jobs:
           VERSION=$(npm view @x402/axios version 2>/dev/null || echo "0.0.0")
           echo "X402_AXIOS_VERSION=${VERSION}" >> $GITHUB_ENV
 
-      - name: Store old version for comparison
-        run: |
-          OLD_AXIOS=$(node -e "const fs=require('fs');const j=JSON.parse(fs.readFileSync('package.json','utf8'));const c=j.config||{};console.log(c.x402AxiosVersion||'0.0.0')")
-          echo "OLD_X402_AXIOS_VERSION=${OLD_AXIOS}" >> $GITHUB_ENV
-
       - name: Record resolved version in root package.json
         run: |
           node -e "const fs=require('fs');const p='package.json';const j=JSON.parse(fs.readFileSync(p,'utf8'));(j.config??={});j.config.x402AxiosVersion=process.env.X402_AXIOS_VERSION;fs.writeFileSync(p,JSON.stringify(j,null,2));"
@@ -79,58 +74,28 @@ jobs:
             echo "HAS_CHANGES=true" >> $GITHUB_ENV
           fi
 
-      - name: Bump starter package version
+      - name: Bump starter package version to follow upstream
         if: ${{ env.HAS_CHANGES == 'true' }}
         run: |
           node <<'EOF'
           const fs = require('fs');
           const p = 'package.json';
           const j = JSON.parse(fs.readFileSync(p, 'utf-8'));
-          const v = j.version || '0.0.0';
-          const parts = v.split('.').map(n => parseInt(n, 10));
-          while (parts.length < 3) parts.push(0);
 
-          const parseVersion = (v) => {
-            if (!v || v === '0.0.0') return { major: 0, minor: 0, patch: 0 };
-            const parts = v.split('.').map(n => parseInt(n, 10));
-            return {
-              major: isNaN(parts[0]) ? 0 : parts[0],
-              minor: isNaN(parts[1]) ? 0 : parts[1],
-              patch: isNaN(parts[2]) ? 0 : parts[2],
-            };
-          };
+          const upstream = process.env.X402_AXIOS_VERSION || '0.0.0';
+          const [upMajor, upMinor] = upstream.split('.').map(Number);
+          const [curMajor, curMinor, curPatch] = (j.version || '0.0.0').split('.').map(Number);
 
-          const compareVersions = (oldV, newV) => {
-            if (oldV === '0.0.0') return 'none'; // New dependency, don't count as change
-            const old = parseVersion(oldV);
-            const new_ = parseVersion(newV);
-
-            if (old.major < new_.major) return 'major';
-            if (old.major === new_.major && old.minor < new_.minor) return 'minor';
-            if (old.major === new_.major && old.minor === new_.minor && old.patch < new_.patch) return 'patch';
-            return 'none';
-          };
-
-          const oldAxios = process.env.OLD_X402_AXIOS_VERSION || '0.0.0';
-          const newAxios = process.env.X402_AXIOS_VERSION || '0.0.0';
-          const change = compareVersions(oldAxios, newAxios);
-
-          if (change === 'major' || change === 'minor') {
-            parts[1] = (parts[1] || 0) + 1;
-            parts[2] = 0;
-            console.log(`Detected ${change} version change in @x402/axios: ${oldAxios} → ${newAxios}`);
-            console.log('Bumping minor version');
+          if (curMajor === upMajor && curMinor === upMinor) {
+            j.version = `${upMajor}.${upMinor}.${curPatch + 1}`;
           } else {
-            parts[2] = (parts[2] || 0) + 1;
-            console.log('Only patch changes detected, bumping patch version');
+            j.version = `${upMajor}.${upMinor}.0`;
           }
 
-          j.version = parts.join('.');
           fs.writeFileSync(p, JSON.stringify(j, null, 2));
-          console.log(`Bumped version to ${j.version}`);
+          console.log(`Starter version set to ${j.version} (tracking @x402/axios@${upstream})`);
           EOF
         env:
-          OLD_X402_AXIOS_VERSION: ${{ env.OLD_X402_AXIOS_VERSION }}
           X402_AXIOS_VERSION: ${{ env.X402_AXIOS_VERSION }}
 
       - name: Open PR with changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payai/x402-axios-starter",
-  "version": "1.0.0",
+  "version": "2.3.0",
   "private": false,
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
- Version now tracks @x402/axios major.minor (currently 2.3.0)
- Simplified sync version bump: match upstream major.minor, increment patch
- Removed old/new version comparison logic